### PR TITLE
add circle CI system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,8 @@ jobs:
               -v /tmp/workspace/data/ds114_test1:/bids_dataset \
               -v ${HOME}/outputs1:/outputs \
               snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
+            ls ${HOME}/outputs1
+            ls ${HOME}/outputs1/sub*
           no_output_timeout: 6h
 
       - run: mkdir -p ${HOME}/outputs2
@@ -120,6 +122,8 @@ jobs:
               -v /tmp/workspace/data/ds114_test2:/bids_dataset \
               -v ${HOME}/outputs2:/outputs \
               snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
+            ls ${HOME}/outputs2
+            ls ${HOME}/outputs2/sub*              
           no_output_timeout: 6h
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ jobs:
     steps:
     - attach_workspace:
         at: /tmp/workspace
-    - setup_remote_docker
     - run: docker load -i /tmp/workspace/image.tar
 
     - run: mkdir -p ${HOME}/outputs1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test1:/bids_dataset \
             -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
         no_output_timeout: 6h
     - run:
         name: group level tests for single session dataset    
@@ -101,7 +101,7 @@ jobs:
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test1:/bids_dataset \
             -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
         no_output_timeout: 6h
 
     - run: mkdir -p ${HOME}/outputs2
@@ -111,7 +111,7 @@ jobs:
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test2:/bids_dataset \
             -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
         no_output_timeout: 6h
     - run:
         name: group level tests for a longitudinal dataset       
@@ -119,7 +119,7 @@ jobs:
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test2:/bids_dataset \
             -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
         no_output_timeout: 6h
 
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,135 +7,133 @@ jobs:
       image: ubuntu-2204:2022.10.2
 
     steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - my_cache
+      - checkout
+      - restore_cache:
+          keys:
+            - my_cache
 
-    - run:
-        name: "Get test data: ds114_test1"
-        command: |
-          if [[ ! -d ~/data/ds114_test1 ]]; \
-            then wget -c -O ${HOME}/ds114_test1.tar "https://osf.io/download/zerfq/" && \
-            mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data;
-          fi
-    - run:
-        name: "Get test data: ds114_test2"
-        command: |
-          if [[ ! -d ~/data/ds114_test2 ]]; \
-            then wget -c -O ${HOME}/ds114_test2.tar "https://osf.io/download/eg4ma/" && \
-            mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test2.tar -C ${HOME}/data;
-          fi
-    - run:
-        command: |
-          if [[ -e ~/docker/image.tar ]]; \
-            then docker load -i ~/docker/image.tar;
-          fi
-          git describe --tags --always > version
-          docker build -t snakebids/${CIRCLE_PROJECT_REPONAME,,} .
-          mkdir -p ~/docker; 
-          docker save "snakebids/${CIRCLE_PROJECT_REPONAME,,}" > ~/docker/image.tar
-        no_output_timeout: 6h
+      - run:
+          name: "Get test data: ds114_test1"
+          command: |
+            if [[ ! -d ~/data/ds114_test1 ]]; \
+              then wget -c -O ${HOME}/ds114_test1.tar "https://osf.io/download/zerfq/" && \
+              mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data;
+            fi
+      - run:
+          name: "Get test data: ds114_test2"
+          command: |
+            if [[ ! -d ~/data/ds114_test2 ]]; \
+              then wget -c -O ${HOME}/ds114_test2.tar "https://osf.io/download/eg4ma/" && \
+              mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test2.tar -C ${HOME}/data;
+            fi
+      - run:
+          command: |
+            if [[ -e ~/docker/image.tar ]]; \
+              then docker load -i ~/docker/image.tar;
+            fi
+            git describe --tags --always > version
+            docker build -t snakebids/${CIRCLE_PROJECT_REPONAME,,} .
+            mkdir -p ~/docker; 
+            docker save "snakebids/${CIRCLE_PROJECT_REPONAME,,}" > ~/docker/image.tar
+          no_output_timeout: 6h
 
-    - save_cache:
-        key: my_cache
-        paths:
-        - ~/docker
-        - ~/data
+      - save_cache:
+          key: my_cache
+          paths:
+            - ~/docker
+            - ~/data
 
-    - persist_to_workspace:
-        root: ~/docker
-        paths:
-        - image.tar
+      - persist_to_workspace:
+          root: ~/docker
+          paths:
+            - image.tar
 
   test_on_internal_data:
     machine:
       image: ubuntu-2204:2022.10.2
 
     steps:
-    - attach_workspace:
-        at: /tmp/workspace
+      - attach_workspace:
+          at: /tmp/workspace
 
-    - run: docker load -i /tmp/workspace/image.tar
+      - run: docker load -i /tmp/workspace/image.tar
 
-    - run: mkdir -p ${HOME}/outputs1
+      - run: mkdir -p ${HOME}/outputs1
 
-    - run:
-        name: "Print version"
-        command: |
-          docker run -ti --rm --read-only \
-            -v ${HOME}/test_data:/bids_dir \
-            -v ${HOME}/outputs1:/outputs1 \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version
+      - run:
+          name: "Print version"
+          command: |
+            docker run -ti --rm \
+              -v ${HOME}/test_data:/bids_dir \
+              -v ${HOME}/outputs1:/outputs1 \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version
 
-    - run:
-        name: "Test on dummy data"
-        command: |
-          docker run -ti --rm --read-only \
-            -v /test_data:/bids_dir \
-            -v /outputs1:/outputs1 \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version  -np -c1          
-
+      - run:
+          name: "Test on dummy data"
+          command: |
+            docker run -ti --rm \
+              -v /test_data:/bids_dir \
+              -v /outputs1:/outputs1 \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version  -np -c1
 
   test_on_real_data:
     machine:
       image: ubuntu-2204:2022.10.2
 
     steps:
-    - attach_workspace:
-        at: /tmp/workspace
-    - run: docker load -i /tmp/workspace/image.tar
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: docker load -i /tmp/workspace/image.tar
 
-    - run: mkdir -p ${HOME}/outputs1
-    - run:
-        name: participant level tests for single session dataset
-        command: |
-          docker run -ti --rm --read-only \
-            -v /tmp/workspace/data/ds114_test1:/bids_dataset \
-            -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
-        no_output_timeout: 6h
-    - run:
-        name: group level tests for single session dataset    
-        command: |
-          docker run -ti --rm --read-only \
-            -v /tmp/workspace/data/ds114_test1:/bids_dataset \
-            -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
-        no_output_timeout: 6h
+      - run: mkdir -p ${HOME}/outputs1
+      - run:
+          name: participant level tests for single session dataset
+          command: |
+            docker run -ti --rm \
+              -v /tmp/workspace/data/ds114_test1:/bids_dataset \
+              -v ${HOME}/outputs1:/outputs \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
+          no_output_timeout: 6h
+      - run:
+          name: group level tests for single session dataset
+          command: |
+            docker run -ti --rm \
+              -v /tmp/workspace/data/ds114_test1:/bids_dataset \
+              -v ${HOME}/outputs1:/outputs \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
+          no_output_timeout: 6h
 
-    - run: mkdir -p ${HOME}/outputs2
-    - run:
-        name: participant level tests for a longitudinal dataset   
-        command: |
-          docker run -ti --rm --read-only \
-            -v /tmp/workspace/data/ds114_test2:/bids_dataset \
-            -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
-        no_output_timeout: 6h
-    - run:
-        name: group level tests for a longitudinal dataset       
-        command: |
-          docker run -ti --rm --read-only \
-            -v /tmp/workspace/data/ds114_test2:/bids_dataset \
-            -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
-        no_output_timeout: 6h
+      - run: mkdir -p ${HOME}/outputs2
+      - run:
+          name: participant level tests for a longitudinal dataset
+          command: |
+            docker run -ti --rm \
+              -v /tmp/workspace/data/ds114_test2:/bids_dataset \
+              -v ${HOME}/outputs2:/outputs \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
+          no_output_timeout: 6h
+      - run:
+          name: group level tests for a longitudinal dataset
+          command: |
+            docker run -ti --rm \
+              -v /tmp/workspace/data/ds114_test2:/bids_dataset \
+              -v ${HOME}/outputs2:/outputs \
+              snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
+          no_output_timeout: 6h
 
-    - store_artifacts:
-        path: ~/output1
-    - store_artifacts:
-        path: ~/output2
+      - store_artifacts:
+          path: ~/output1
+      - store_artifacts:
+          path: ~/output2
 
 workflows:
   build-test-deploy:
     jobs:
-    - build
-    - test_on_real_data:
-        requires:
-        - build
-    - test_on_internal_data:
-        requires:
-        - build
-
+      - build
+      - test_on_real_data:
+          requires:
+            - build
+      - test_on_internal_data:
+          requires:
+            - build
 # VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,11 @@ jobs:
             - ~/data
 
       - persist_to_workspace:
-          root: ~/docker
+          root: /home/circleci
           paths:
-            - image.tar
+          - data/ds114_test1
+          - data/ds114_test2
+          - docker/image.tar
 
   test_on_internal_data:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
       - run:
           name: participant level tests for single session dataset
           command: |
+            ls -l /tmp/workspace/data/ds114_test1
             docker run -ti --rm \
               -v /tmp/workspace/data/ds114_test1:/bids_dataset \
               -v ${HOME}/outputs1:/outputs \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
 
-      - run: docker load -i /tmp/workspace/image.tar
+      - run: docker load -i /tmp/workspace/docker/image.tar
 
       - run: mkdir -p ${HOME}/outputs1
 
@@ -85,7 +85,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: docker load -i /tmp/workspace/image.tar
+      - run: docker load -i /tmp/workspace/docker/image.tar
 
       - run: mkdir -p ${HOME}/outputs1
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ version: 2
 jobs:
   build:
     machine:
-      # https://circleci.com/developer/machine/image/ubuntu-2204
       image: ubuntu-2204:2022.10.2
 
     steps:
@@ -50,8 +49,8 @@ jobs:
         - image.tar
 
   test_on_internal_data:
-    docker:
-    - image:  ubuntu-2204:2022.10.2
+    machine:
+      image: ubuntu-2204:2022.10.2
 
     steps:
     - attach_workspace:
@@ -79,8 +78,8 @@ jobs:
 
 
   test_on_real_data:
-    docker:
-    - image:  ubuntu-2204:2022.10.2
+    machine:
+      image: ubuntu-2204:2022.10.2
 
     steps:
     - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   build:
@@ -91,7 +91,7 @@ jobs:
         name: participant level tests for single session dataset
         command: |
           docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test1:/bids_dataset \
+            -v /tmp/workspace/data/ds114_test1:/bids_dataset \
             -v ${HOME}/outputs1:/outputs \
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
         no_output_timeout: 6h
@@ -99,7 +99,7 @@ jobs:
         name: group level tests for single session dataset    
         command: |
           docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test1:/bids_dataset \
+            -v /tmp/workspace/data/ds114_test1:/bids_dataset \
             -v ${HOME}/outputs1:/outputs \
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
         no_output_timeout: 6h
@@ -109,7 +109,7 @@ jobs:
         name: participant level tests for a longitudinal dataset   
         command: |
           docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test2:/bids_dataset \
+            -v /tmp/workspace/data/ds114_test2:/bids_dataset \
             -v ${HOME}/outputs2:/outputs \
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02 -c1
         no_output_timeout: 6h
@@ -117,7 +117,7 @@ jobs:
         name: group level tests for a longitudinal dataset       
         command: |
           docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test2:/bids_dataset \
+            -v /tmp/workspace/data/ds114_test2:/bids_dataset \
             -v ${HOME}/outputs2:/outputs \
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group -c1
         no_output_timeout: 6h
@@ -128,7 +128,6 @@ jobs:
         path: ~/output2
 
 workflows:
-  version: 2
   build-test-deploy:
     jobs:
     - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,166 @@
+---
+version: 2
+
+jobs:
+  build:
+    machine:
+      # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2022.10.2
+
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - my_cache
+
+    - run:
+        name: "Get test data: ds114_test1"
+        command: |
+
+          if [[ ! -d ~/data/ds114_test1 ]]; \
+            then wget -c -O ${HOME}/ds114_test1.tar "https://osf.io/download/zerfq/" && \
+            mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data;
+          fi
+    - run:
+        name: "Get test data: ds114_test2"
+        command: |
+          if [[ ! -d ~/data/ds114_test2 ]]; \
+            then wget -c -O ${HOME}/ds114_test2.tar "https://osf.io/download/eg4ma/" && \
+            mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test2.tar -C ${HOME}/data;
+          fi
+    - run:
+        command: |
+          if [[ -e ~/docker/image.tar ]]; \
+            then docker load -i ~/docker/image.tar;
+          fi
+    - run: git describe --tags --always > version
+    - run:
+        name: Build image
+        command: docker build -t snakebids/${CIRCLE_PROJECT_REPONAME,,} .
+        no_output_timeout: 6h
+    - run:
+        name: Save image
+        command: |
+          mkdir -p ~/docker; 
+          docker save "snakebids/${CIRCLE_PROJECT_REPONAME,,}" > ~/docker/image.tar
+
+    - save_cache:
+        key: my_cache
+        paths:
+        - ~/docker
+        - ~/data
+
+    - persist_to_workspace:
+        root: ~/docker
+        paths:
+        - image.tar
+
+  test_on_internal_data:
+    docker:
+    - image:  ubuntu-2204:2022.10.2
+
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run: docker load -i /tmp/workspace/image.tar
+
+    - run: mkdir -p ${HOME}/outputs1
+    - run: mkdir -p ${HOME}/outputs2
+
+      # print version
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/test_data:/bids_dir \
+            -v ${HOME}/outputs1:/outputs1 \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version
+
+      # test on dummy data
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v /test_data:/bids_dir \
+            -v /outputs1:/outputs1 \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version  -np -c1          
+
+
+  test_on_real_data:
+    docker:
+    - image:  ubuntu-2204:2022.10.2
+
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run: docker load -i /tmp/workspace/image.tar
+
+    - run: mkdir -p ${HOME}/outputs1
+    - run: mkdir -p ${HOME}/outputs2
+
+      # participant level tests for single session dataset
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test1:/bids_dataset \
+            -v ${HOME}/outputs1:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01
+        no_output_timeout: 6h
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test1:/bids_dataset \
+            -v ${HOME}/outputs1:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02
+        no_output_timeout: 6h
+      # group level test for single session dataset
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test1:/bids_dataset \
+            -v ${HOME}/outputs1:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group
+        no_output_timeout: 6h
+
+      # participant level tests for a longitudinal dataset
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test2:/bids_dataset \
+            -v ${HOME}/outputs2:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01
+        no_output_timeout: 6h
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test2:/bids_dataset \
+            -v ${HOME}/outputs2:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02
+        no_output_timeout: 6h
+      # group level test for a longitudinal dataset
+    - run:
+        command: |
+          docker run -ti --rm --read-only \
+            -v ${HOME}/data/ds114_test2:/bids_dataset \
+            -v ${HOME}/outputs2:/outputs \
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group
+        no_output_timeout: 6h
+
+    - store_artifacts:
+        path: ~/output1
+    - store_artifacts:
+        path: ~/output2
+
+workflows:
+  version: 2
+  build-test-deploy:
+    jobs:
+    - build
+    - test_on_real_data:
+        requires:
+        - build
+    - test_on_internal_data:
+        requires:
+        - build
+
+# VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,22 +62,22 @@ jobs:
     steps:
     - attach_workspace:
         at: /tmp/workspace
-    - setup_remote_docker
+
     - run: docker load -i /tmp/workspace/image.tar
 
     - run: mkdir -p ${HOME}/outputs1
     - run: mkdir -p ${HOME}/outputs2
 
-      # print version
     - run:
+        name: "Print version"
         command: |
           docker run -ti --rm --read-only \
             -v ${HOME}/test_data:/bids_dir \
             -v ${HOME}/outputs1:/outputs1 \
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dir /outputs1 participant --version
 
-      # test on dummy data
     - run:
+        name: "Test on dummy data"
         command: |
           docker run -ti --rm --read-only \
             -v /test_data:/bids_dir \
@@ -95,25 +95,16 @@ jobs:
     - run: docker load -i /tmp/workspace/image.tar
 
     - run: mkdir -p ${HOME}/outputs1
-    - run: mkdir -p ${HOME}/outputs2
-
-      # participant level tests for single session dataset
     - run:
+        name: participant level tests for single session dataset
         command: |
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test1:/bids_dataset \
             -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02
         no_output_timeout: 6h
     - run:
-        command: |
-          docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test1:/bids_dataset \
-            -v ${HOME}/outputs1:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02
-        no_output_timeout: 6h
-      # group level test for single session dataset
-    - run:
+        name: group level tests for single session dataset    
         command: |
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test1:/bids_dataset \
@@ -121,23 +112,17 @@ jobs:
             snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group
         no_output_timeout: 6h
 
-      # participant level tests for a longitudinal dataset
+    - run: mkdir -p ${HOME}/outputs2
     - run:
+        name: participant level tests for a longitudinal dataset   
         command: |
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test2:/bids_dataset \
             -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01
+            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 02
         no_output_timeout: 6h
     - run:
-        command: |
-          docker run -ti --rm --read-only \
-            -v ${HOME}/data/ds114_test2:/bids_dataset \
-            -v ${HOME}/outputs2:/outputs \
-            snakebids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02
-        no_output_timeout: 6h
-      # group level test for a longitudinal dataset
-    - run:
+        name: group level tests for a longitudinal dataset       
         command: |
           docker run -ti --rm --read-only \
             -v ${HOME}/data/ds114_test2:/bids_dataset \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
     - run:
         name: "Get test data: ds114_test1"
         command: |
-
           if [[ ! -d ~/data/ds114_test1 ]]; \
             then wget -c -O ${HOME}/ds114_test1.tar "https://osf.io/download/zerfq/" && \
             mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data;
@@ -33,16 +32,11 @@ jobs:
           if [[ -e ~/docker/image.tar ]]; \
             then docker load -i ~/docker/image.tar;
           fi
-    - run: git describe --tags --always > version
-    - run:
-        name: Build image
-        command: docker build -t snakebids/${CIRCLE_PROJECT_REPONAME,,} .
-        no_output_timeout: 6h
-    - run:
-        name: Save image
-        command: |
+          git describe --tags --always > version
+          docker build -t snakebids/${CIRCLE_PROJECT_REPONAME,,} .
           mkdir -p ~/docker; 
           docker save "snakebids/${CIRCLE_PROJECT_REPONAME,,}" > ~/docker/image.tar
+        no_output_timeout: 6h
 
     - save_cache:
         key: my_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,6 @@ jobs:
     - run: docker load -i /tmp/workspace/image.tar
 
     - run: mkdir -p ${HOME}/outputs1
-    - run: mkdir -p ${HOME}/outputs2
 
     - run:
         name: "Print version"


### PR DESCRIPTION
See output here: https://app.circleci.com/pipelines/github/Remi-Gau/example-snakebids/16/workflows/9b8740fd-4646-4849-9086-9e7be57d20b0

- builds docker image
- test it on internal data
- test it on external data (2 small datasets used by other bids apps test and stored on OSF)